### PR TITLE
fix return value of run function

### DIFF
--- a/pytest_mqtt/mosquitto.py
+++ b/pytest_mqtt/mosquitto.py
@@ -36,6 +36,7 @@ images.settings["mosquitto"] = {
 class Mosquitto(BaseImage):
 
     name = "mosquitto"
+    port = 1883
 
     def check(self):
         # TODO: Add real implementation.
@@ -55,7 +56,7 @@ class Mosquitto(BaseImage):
 
     def run(self):
         self.pull_image()
-        super(Mosquitto, self).run()
+        return super(Mosquitto, self).run()
 
 
 mosquitto_image = Mosquitto()


### PR DESCRIPTION
The `port` is required for the `self.get_port` function, which will be used in the function `run` of `BaseImage`.

Also we need to return the return tuple of base function