### PR TITLE
Improve error handling when Docker daemon is not running

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ pytest-mqtt changelog
 in progress
 ===========
 
+- Improve error handling when Docker daemon is not running. Thanks, @horta.
+
 
 2023-03-15 0.2.0
 ================

--- a/pytest_mqtt/mosquitto.py
+++ b/pytest_mqtt/mosquitto.py
@@ -55,6 +55,12 @@ class Mosquitto(BaseImage):
         docker_client.images.pull(image_name)
 
     def run(self):
+        docker_client = docker.from_env(version=self.docker_version)
+        docker_url = docker_client.api.base_url
+        try:
+            docker_client.ping()
+        except Exception:
+            raise ConnectionError(f"Cannot connect to the Docker daemon at {docker_url}. Is the docker daemon running?")
         self.pull_image()
         return super(Mosquitto, self).run()
 


### PR DESCRIPTION
## About

@horta reported at GH-4 about long error stacktraces without a specific error message, when the Docker daemon is not running.

## Details

While this patch does not truncate the long exception output, at least it adds a more significant error message.

## Screenshot

![image](https://github.com/mqtt-tools/pytest-mqtt/assets/453543/516152a5-d467-4dfd-a598-8768ac1f93dc)
