### PR TITLE
Fix improving error handling when Docker daemon is not running

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Check code style
       if: matrix.python-version != '3.6'
       run: |
-        poe check-style
+        poe lint
 
     - name: Run tests
       run: |

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ pytest-mqtt changelog
 in progress
 ===========
 
+- Fix improving error handling when Docker daemon is not running.
+
 
 2023-07-28 0.3.0
 ================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,11 +141,17 @@ line-length = 120
 # ===================
 
 [tool.poe.tasks]
+
+check = [
+  "lint",
+  "test",
+]
+
 format = [
   {cmd="black ."},
   {cmd="isort pytest_mqtt testing"},
 ]
-check-style = [
+lint = [
   {cmd="ruff ."},
   {cmd="black --check ."},
   {cmd="isort --check pytest_mqtt testing"},

--- a/pytest_mqtt/mosquitto.py
+++ b/pytest_mqtt/mosquitto.py
@@ -55,8 +55,11 @@ class Mosquitto(BaseImage):
         docker_client.images.pull(image_name)
 
     def run(self):
-        docker_client = docker.from_env(version=self.docker_version)
-        docker_url = docker_client.api.base_url
+        try:
+            docker_client = docker.from_env(version=self.docker_version)
+            docker_url = docker_client.api.base_url
+        except Exception:
+            raise ConnectionError("Cannot connect to the Docker daemon. Is the docker daemon running?")
         try:
             docker_client.ping()
         except Exception:


### PR DESCRIPTION
## About

GH-5 did not quite make it for @horta, see https://github.com/mqtt-tools/pytest-mqtt/issues/4#issuecomment-1655739280. While it works well on my machine, this patch tries to improve the situation in cases I can't reproduce.
