### PR TITLE
Add support for paho-mqtt 2.x, retaining compatibility for 1.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,13 +23,17 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        paho-mqtt-version: ["1.*", "2.*"]
       fail-fast: false
 
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
 
-    name: Python ${{ matrix.python-version }} on OS ${{ matrix.os }}
+    name:
+      Python ${{ matrix.python-version }},
+      paho-mqtt ${{ matrix.paho-mqtt-version }}
+      on OS ${{ matrix.os }}
     steps:
 
     - name: Acquire sources
@@ -52,6 +56,9 @@ jobs:
 
         # Install package in editable mode.
         pip install --editable=.[test,develop]
+
+        # Explicitly install designated version of paho-mqtt.
+        pip install --upgrade 'paho-mqtt==${{ matrix.paho-mqtt-version }}'
 
     - name: Check code style
       if: matrix.python-version != '3.6' && matrix.python-version != '3.7'

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ in progress
 - Accept command line options ``--mqtt-host`` and ``--mqtt-port``,
   in order to connect to an MQTT broker on a different endpoint
   than ``localhost:1883``. Thanks, @zedfmario.
+- Add support for paho-mqtt 2.x, retaining compatibility for 1.x
 
 
 2023-08-03 0.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ classifiers = [
 dependencies = [
   "dataclasses; python_version<'3.7'",
   "importlib-metadata; python_version<'3.8'",
-  "paho-mqtt<2",
+  "paho-mqtt<3",
   "pytest-docker-fixtures<2",
 ]
 

--- a/pytest_mqtt/capmqtt.py
+++ b/pytest_mqtt/capmqtt.py
@@ -29,7 +29,13 @@ logger = logging.getLogger(__name__)
 class MqttClientAdapter(threading.Thread):
     def __init__(self, on_message_callback: t.Optional[t.Callable] = None, host: str = "localhost", port: int = 1883):
         super().__init__()
-        self.client: mqtt.Client = mqtt.Client()
+        self.client: mqtt.Client
+        if not hasattr(mqtt, "CallbackAPIVersion"):
+            # paho-mqtt 1.x
+            self.client = mqtt.Client()
+        else:
+            # paho-mqtt 2.x
+            self.client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1)
         self.on_message_callback = on_message_callback
         self.host = host
         self.port = int(port)


### PR DESCRIPTION
## About
Updating to paho-mqtt 2.0 needs manual interventions, because it introduced breaking changes. This patch makes it so that pytest-mqtt is compatible with both paho-mqtt 1.x and 2.x, for the time being.

## References
- https://github.com/mqtt-tools/mqttwarn/issues/694
- https://github.com/mqtt-tools/pytest-mqtt/pull/12

/cc @dlangille, @adequacy1, @jpmens
