### PR TITLE
Add a little delay to the Mosquitto fixture

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ pytest-mqtt changelog
 
 in progress
 ===========
+- Added a little delay to the Mosquitto fixture. Possibly faster GitHub
+  runners made MQTT software tests fail on the LorryStream project.
 
 2024-05-08 0.4.1
 ================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ develop = [
   "isort<6",
   "black<25",
   "poethepoet<1",
-  "ruff",
+  "ruff<0.6",
 ]
 release = [
   "build<2",
@@ -152,7 +152,7 @@ format = [
   {cmd="isort pytest_mqtt testing"},
 ]
 lint = [
-  {cmd="ruff ."},
+  {cmd="ruff check ."},
   {cmd="black --check ."},
   {cmd="isort --check pytest_mqtt testing"},
 ]

--- a/pytest_mqtt/mosquitto.py
+++ b/pytest_mqtt/mosquitto.py
@@ -22,7 +22,7 @@ from pytest_docker_fixtures import images
 from pytest_docker_fixtures.containers._base import BaseImage
 
 from pytest_mqtt.model import MqttSettings
-from pytest_mqtt.util import probe_tcp_connect
+from pytest_mqtt.util import delay, probe_tcp_connect
 
 images.settings["mosquitto"] = {
     "image": "eclipse-mosquitto",
@@ -108,4 +108,5 @@ def mosquitto(mqtt_settings: MqttSettings):
         yield os.environ["MOSQUITTO"].split(":")
     else:
         yield mosquitto_image.run()
+        delay()
         mosquitto_image.stop()


### PR DESCRIPTION
## Problem
Possibly faster GitHub runners made MQTT software tests fail on the LorryStream project.

## Solution
Add a little delay.

## References
- https://github.com/daq-tools/lorrystream/pull/120
- https://github.com/daq-tools/lorrystream/pull/122