### PR TITLE
CI: Verify support on Python 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         paho-mqtt-version: ["1.*", "2.*"]
       fail-fast: false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Communications",
   "Topic :: Education",
   "Topic :: Home Automation",


### PR DESCRIPTION
## About
[Python 3.13.0](https://www.python.org/downloads/release/python-3130/) has been released on Oct. 7, 2024. This PR intends to add CI verification.

## References
- https://github.com/crate/sqlalchemy-cratedb/pull/167
