### PR TITLE
Improve paho-mqtt and mosqitto fixtures

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ pytest-mqtt changelog
 
 in progress
 ===========
+- paho-mqtt: Ignore deprecation warnings about Callback API v1
 
 2024-07-29 0.4.2
 ================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ pytest-mqtt changelog
 in progress
 ===========
 - paho-mqtt: Ignore deprecation warnings about Callback API v1
+- mosquitto: Don't always pull OCI image
 
 2024-07-29 0.4.2
 ================

--- a/pytest_mqtt/capmqtt.py
+++ b/pytest_mqtt/capmqtt.py
@@ -16,6 +16,7 @@ Source: https://github.com/hiveeyes/terkin-datalogger/blob/0.13.0/test/fixtures/
 import logging
 import threading
 import typing as t
+import warnings
 
 import paho.mqtt.client as mqtt
 import pytest
@@ -35,7 +36,9 @@ class MqttClientAdapter(threading.Thread):
             self.client = mqtt.Client()
         else:
             # paho-mqtt 2.x
-            self.client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1)
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=DeprecationWarning)
+                self.client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1)
         self.on_message_callback = on_message_callback
         self.host = host
         self.port = int(port)

--- a/pytest_mqtt/mosquitto.py
+++ b/pytest_mqtt/mosquitto.py
@@ -57,7 +57,8 @@ class Mosquitto(BaseImage):
         """
         docker_client = docker.from_env(version=self.docker_version)
         image_name = self.image
-        docker_client.images.pull(image_name)
+        if not docker_client.images.list(name=image_name):
+            docker_client.images.pull(image_name)
 
     def run(self):
         try:


### PR DESCRIPTION
## What's Inside
- [paho-mqtt: Ignore deprecation warnings about Callback API v1](https://github.com/mqtt-tools/pytest-mqtt/commit/bea0d52be78ff72c207b7339515dc78eb0f2e2d6)
- [mosquitto: Don't always pull OCI image](https://github.com/mqtt-tools/pytest-mqtt/commit/d04576c07d314589ba02d607c14d17eb35d7c966)