### PR TITLE
Add support for connecting as named user

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,9 @@ Capture MQTT messages, using the `Paho MQTT Python Client`_, in the spirit of
 MQTT server host and port are configurable via pytest cli arguments:
 ``--mqtt-host`` and ``--mqtt-port``. Default values are ``localhost``/``1883``.
 
+You may additionally specify a username and password for connecting to the broker with:
+``--mqtt-username`` and ``--mqtt-password``. Default values are ``guest``/``guest``.
+
 ``mosquitto`` fixture
 =====================
 

--- a/pytest_mqtt/capmqtt.py
+++ b/pytest_mqtt/capmqtt.py
@@ -28,7 +28,14 @@ logger = logging.getLogger(__name__)
 
 
 class MqttClientAdapter(threading.Thread):
-    def __init__(self, on_message_callback: t.Optional[t.Callable] = None, host: str = "localhost", port: int = 1883, username: str = "guest", password: str = "guest"):
+    def __init__(
+        self,
+        on_message_callback: t.Optional[t.Callable] = None,
+        host: str = "localhost",
+        port: int = 1883,
+        username: str = "guest",
+        password: str = "guest",
+    ):
         super().__init__()
         self.client: mqtt.Client
         if not hasattr(mqtt, "CallbackAPIVersion"):
@@ -96,12 +103,21 @@ class MqttClientAdapter(threading.Thread):
 class MqttCaptureFixture:
     """Provides access and control of log capturing."""
 
-    def __init__(self, decode_utf8: t.Optional[bool], host: str = "localhost", port: int = 1883, username: str = "guest", password: str = "guest") -> None:
+    def __init__(
+        self,
+        decode_utf8: t.Optional[bool],
+        host: str = "localhost",
+        port: int = 1883,
+        username: str = "guest",
+        password: str = "guest",
+    ) -> None:
         """Creates a new funcarg."""
         self._buffer: t.List[MqttMessage] = []
         self._decode_utf8: bool = decode_utf8 or False
 
-        self.mqtt_client = MqttClientAdapter(on_message_callback=self.on_message, host=host, port=port, username=username, password=password)
+        self.mqtt_client = MqttClientAdapter(
+            on_message_callback=self.on_message, host=host, port=port, username=username, password=password
+        )
         self.mqtt_client.start()
         # time.sleep(0.1)
 
@@ -156,7 +172,9 @@ def capmqtt(request, mqtt_settings: MqttSettings):
         or getattr(request.module, "capmqtt_decode_utf8", False)
         or request.node.get_closest_marker("capmqtt_decode_utf8") is not None
     )
-    result = MqttCaptureFixture(decode_utf8=capmqtt_decode_utf8, host=host, port=port, username=username, password=password)
+    result = MqttCaptureFixture(
+        decode_utf8=capmqtt_decode_utf8, host=host, port=port, username=username, password=password
+    )
     delay()
     yield result
     result.finalize()

--- a/pytest_mqtt/model.py
+++ b/pytest_mqtt/model.py
@@ -17,3 +17,5 @@ class MqttMessage:
 class MqttSettings:
     host: str
     port: int
+    username: str
+    password: str

--- a/pytest_mqtt/mosquitto.py
+++ b/pytest_mqtt/mosquitto.py
@@ -84,6 +84,9 @@ def is_mosquitto_running(host: str, port: int) -> bool:
 def pytest_addoption(parser) -> None:
     parser.addoption("--mqtt-host", action="store", type=str, default="localhost", help="MQTT host name")
     parser.addoption("--mqtt-port", action="store", type=int, default=1883, help="MQTT port number")
+    parser.addoption("--mqtt-username", action="store", type=str, default="guest", help="Username for connection")
+    parser.addoption("--mqtt-password", action="store", type=str, default="guest", help="Password for connection")
+    
 
 
 @pytest.fixture(scope="session")
@@ -91,6 +94,8 @@ def mqtt_settings(pytestconfig) -> MqttSettings:
     return MqttSettings(
         host=pytestconfig.getoption("--mqtt-host"),
         port=pytestconfig.getoption("--mqtt-port"),
+        username=pytestconfig.getoption("--mqtt-username"),
+        password=pytestconfig.getoption("--mqtt-password"),
     )
 
 

--- a/pytest_mqtt/mosquitto.py
+++ b/pytest_mqtt/mosquitto.py
@@ -86,7 +86,6 @@ def pytest_addoption(parser) -> None:
     parser.addoption("--mqtt-port", action="store", type=int, default=1883, help="MQTT port number")
     parser.addoption("--mqtt-username", action="store", type=str, default="guest", help="Username for connection")
     parser.addoption("--mqtt-password", action="store", type=str, default="guest", help="Password for connection")
-    
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Summary
Adds optional authentication support by allowing username and password to be set via CLI arguments. 

This should enable connections to brokers which disallow anonymous connections or if authentication is expected.

Defaults remain unchanged (guest/guest), so existing usage should be unaffected.

## Details

- Adds --mqtt-username and --mqtt-password CLI args to pytest-mqtt
- Updates the fixtures / clients to accept credentials
- Documents new arguments in README.rst