### PR TITLE
add --no-subscribe-all option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ pytest-mqtt changelog
 
 in progress
 ===========
+- Add ``--no-subscribe-all`` command line option, for testing against a busy MQTT broker.
 
 2025-12-24 0.6.2
 ================

--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ MQTT server host and port are configurable via pytest cli arguments:
 You may additionally specify a username and password for connecting to the broker with:
 ``--mqtt-username`` and ``--mqtt-password``. Default values are ``guest``/``guest``.
 
-By default, the test fixture subscribes to all topics, listening on "#". This can be
+By default, the test fixture subscribes to all topics, listening on ``#``. This can be
 disabled with the ``--no-subscribe-all`` option. You can then subscribe to the topics
 you are interested in within each test using ``capmqtt.mqtt_client.client.subscribe(cpe.info)``.
 

--- a/README.rst
+++ b/README.rst
@@ -62,8 +62,8 @@ You may additionally specify a username and password for connecting to the broke
 ``--mqtt-username`` and ``--mqtt-password``. Default values are ``guest``/``guest``.
 
 By default, the test fixture subscribes to all topics, listening on "#". This can be
-disabled with the ''--no-subscribe-all`` option. You can then subscribe to the topics
-you are interested in within each test using ``capmqtt.mqtt_client.client.subscribe(cpe.info)``
+disabled with the ``--no-subscribe-all`` option. You can then subscribe to the topics
+you are interested in within each test using ``capmqtt.mqtt_client.client.subscribe(cpe.info)``.
 
 ``mosquitto`` fixture
 =====================

--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,10 @@ MQTT server host and port are configurable via pytest cli arguments:
 You may additionally specify a username and password for connecting to the broker with:
 ``--mqtt-username`` and ``--mqtt-password``. Default values are ``guest``/``guest``.
 
+By default, the test fixture subscribes to all topics, listening on "#". This can be
+disabled with the ''--no-subscribe-all`` option. You can then subscribe to the topics
+you are interested in within each test using ``capmqtt.mqtt_client.client.subscribe(cpe.info)``
+
 ``mosquitto`` fixture
 =====================
 

--- a/pytest_mqtt/capmqtt.py
+++ b/pytest_mqtt/capmqtt.py
@@ -35,6 +35,7 @@ class MqttClientAdapter(threading.Thread):
         port: int = 1883,
         username: str = "guest",
         password: str = "guest",
+        subscribe_all: bool = True,
     ):
         super().__init__()
         self.client: mqtt.Client
@@ -51,6 +52,7 @@ class MqttClientAdapter(threading.Thread):
         self.port = int(port)
         self.username = username
         self.password = password
+        self.subscribe_all = subscribe_all
 
         self.setup()
 
@@ -66,7 +68,8 @@ class MqttClientAdapter(threading.Thread):
 
         logger.debug("[PYTEST] Connecting to MQTT broker")
         client.connect(host=self.host, port=self.port)
-        client.subscribe("#")
+        if self.subscribe_all:
+            client.subscribe("#")
 
     def run(self) -> None:
         self.client.loop_start()
@@ -117,13 +120,14 @@ class MqttCaptureFixture:
         port: int = 1883,
         username: str = "guest",
         password: str = "guest",
+        subscribe_all: bool = True,
     ) -> None:
         """Creates a new funcarg."""
         self._buffer: t.List[MqttMessage] = []
         self._decode_utf8: bool = decode_utf8 or False
 
         self.mqtt_client = MqttClientAdapter(
-            on_message_callback=self.on_message, host=host, port=port, username=username, password=password
+            on_message_callback=self.on_message, host=host, port=port, username=username, password=password, subscribe_all=subscribe_all
         )
         self.mqtt_client.start()
         # time.sleep(0.1)
@@ -178,6 +182,7 @@ def capmqtt(request, mqtt_settings: MqttSettings):
 
     host, port = mqtt_settings.host, mqtt_settings.port
     username, password = mqtt_settings.username, mqtt_settings.password
+    subscribe_all = mqtt_settings.subscribe_all
 
     capmqtt_decode_utf8 = (
         getattr(request.config.option, "capmqtt_decode_utf8", False)
@@ -185,7 +190,7 @@ def capmqtt(request, mqtt_settings: MqttSettings):
         or request.node.get_closest_marker("capmqtt_decode_utf8") is not None
     )
     result = MqttCaptureFixture(
-        decode_utf8=capmqtt_decode_utf8, host=host, port=port, username=username, password=password
+        decode_utf8=capmqtt_decode_utf8, host=host, port=port, username=username, password=password, subscribe_all=subscribe_all
     )
     delay()
     yield result

--- a/pytest_mqtt/capmqtt.py
+++ b/pytest_mqtt/capmqtt.py
@@ -127,7 +127,12 @@ class MqttCaptureFixture:
         self._decode_utf8: bool = decode_utf8 or False
 
         self.mqtt_client = MqttClientAdapter(
-            on_message_callback=self.on_message, host=host, port=port, username=username, password=password, subscribe_all=subscribe_all
+            on_message_callback=self.on_message,
+            host=host,
+            port=port,
+            username=username,
+            password=password,
+            subscribe_all=subscribe_all,
         )
         self.mqtt_client.start()
         # time.sleep(0.1)
@@ -190,7 +195,12 @@ def capmqtt(request, mqtt_settings: MqttSettings):
         or request.node.get_closest_marker("capmqtt_decode_utf8") is not None
     )
     result = MqttCaptureFixture(
-        decode_utf8=capmqtt_decode_utf8, host=host, port=port, username=username, password=password, subscribe_all=subscribe_all
+        decode_utf8=capmqtt_decode_utf8,
+        host=host,
+        port=port,
+        username=username,
+        password=password,
+        subscribe_all=subscribe_all,
     )
     delay()
     yield result

--- a/pytest_mqtt/model.py
+++ b/pytest_mqtt/model.py
@@ -19,3 +19,4 @@ class MqttSettings:
     port: int
     username: str
     password: str
+    subscribe_all: bool

--- a/pytest_mqtt/mosquitto.py
+++ b/pytest_mqtt/mosquitto.py
@@ -86,6 +86,7 @@ def pytest_addoption(parser) -> None:
     parser.addoption("--mqtt-port", action="store", type=int, default=1883, help="MQTT port number")
     parser.addoption("--mqtt-username", action="store", type=str, default="guest", help="Username for connection")
     parser.addoption("--mqtt-password", action="store", type=str, default="guest", help="Password for connection")
+    parser.addoption("--no-subscribe-all", action="store_false", dest="subscribe_all", help="Do not subscribe to all topics")
 
 
 @pytest.fixture(scope="session")
@@ -95,6 +96,7 @@ def mqtt_settings(pytestconfig) -> MqttSettings:
         port=pytestconfig.getoption("--mqtt-port"),
         username=pytestconfig.getoption("--mqtt-username"),
         password=pytestconfig.getoption("--mqtt-password"),
+        subscribe_all=pytestconfig.getoption("subscribe_all"),
     )
 
 

--- a/pytest_mqtt/mosquitto.py
+++ b/pytest_mqtt/mosquitto.py
@@ -86,7 +86,9 @@ def pytest_addoption(parser) -> None:
     parser.addoption("--mqtt-port", action="store", type=int, default=1883, help="MQTT port number")
     parser.addoption("--mqtt-username", action="store", type=str, default="guest", help="Username for connection")
     parser.addoption("--mqtt-password", action="store", type=str, default="guest", help="Password for connection")
-    parser.addoption("--no-subscribe-all", action="store_false", dest="subscribe_all", help="Do not subscribe to all topics")
+    parser.addoption(
+        "--no-subscribe-all", action="store_false", dest="subscribe_all", help="Do not subscribe to all topics"
+    )
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
This pull request adds a pytest command line option called `--no-subscribe-all` which disables the automatic subscription to all topics. When using this option, tests can be ran against a busy production MQTT broker which would have a lot of traffic that is not interesting to the test itself.

Subscriptions can be made manually in each test using `capmqtt.mqtt_client.client.subscribe("topic/goes/here")`