### PR TITLE
CI: Validate on Python 3.15

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: ["ubuntu-22.04"]
         python-version: [
@@ -33,7 +34,10 @@ jobs:
           "3.14",
         ]
         paho-mqtt-version: ["1.*", "2.*"]
-      fail-fast: false
+        include:
+          - os: "ubuntu-latest"
+            paho-mqtt-version: "2.*"
+            python-version: "3.15-dev"
 
     env:
       OS: ${{ matrix.os }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ pytest-mqtt changelog
 
 in progress
 ===========
+- CI: Validated on Python 3.15
 
 2026-01-28 0.7.0
 ================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Topic :: Communications",
   "Topic :: Education",
   "Topic :: Home Automation",


### PR DESCRIPTION
Just maintenance. Python 3.15 is around the corner.