### PR TITLE
CI: Validate on Python 3.14t

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,7 @@ jobs:
           "3.12",
           "3.13",
           "3.14",
+          "3.14t",
         ]
         paho-mqtt-version: ["1.*", "2.*"]
       fail-fast: false


### PR DESCRIPTION
Validate pytest-mqtt on [free-threaded Python](https://docs.python.org/3/howto/free-threading-python.html).