### PR TITLE
Chore(deps-dev): Update ruff to <0.17 with its fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ optional-dependencies.develop = [
   "mypy<2.4",
   "poethepoet<1",
   "pyproject-fmt<3",
-  "ruff<0.16",
+  "ruff<0.17",
   "validate-pyproject<1",
 ]
 optional-dependencies.release = [

--- a/pytest_mqtt/__init__.py
+++ b/pytest_mqtt/__init__.py
@@ -1,7 +1,7 @@
 try:
-    from importlib.metadata import PackageNotFoundError, version  # noqa
+    from importlib.metadata import PackageNotFoundError, version
 except ImportError:  # pragma: no cover
-    from importlib_metadata import PackageNotFoundError, version  # type: ignore[no-redef]  # noqa
+    from importlib_metadata import PackageNotFoundError, version  # type: ignore[no-redef]
 
 from .model import MqttMessage  # noqa: F401
 

--- a/pytest_mqtt/capmqtt.py
+++ b/pytest_mqtt/capmqtt.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2020-2022 Andreas Motl <andreas.motl@panodata.org>
 # Copyright (c) 2020-2022 Richard Pobering <richard.pobering@panodata.org>
 #
@@ -13,6 +12,8 @@ Source: https://github.com/hiveeyes/terkin-datalogger/blob/0.13.0/test/fixtures/
 
 .. _Paho MQTT Python Client: https://github.com/eclipse/paho.mqtt.python
 """
+
+from __future__ import annotations
 
 import logging
 import threading
@@ -30,7 +31,7 @@ logger = logging.getLogger(__name__)
 class MqttClientAdapter(threading.Thread):
     def __init__(
         self,
-        on_message_callback: t.Optional[t.Callable] = None,
+        on_message_callback: t.Callable | None = None,
         host: str = "localhost",
         port: int = 1883,
         username: str = "guest",
@@ -102,7 +103,7 @@ class MqttClientAdapter(threading.Thread):
     def publish(
         self,
         topic: str,
-        payload: t.Union[str, bytes, bytearray, int, float, None],
+        payload: str | bytes | bytearray | float | None,
         **kwargs,
     ) -> mqtt.MQTTMessageInfo:
         message_info = self.client.publish(topic, payload, **kwargs)
@@ -115,7 +116,7 @@ class MqttCaptureFixture:
 
     def __init__(
         self,
-        decode_utf8: t.Optional[bool],
+        decode_utf8: bool | None,
         host: str = "localhost",
         port: int = 1883,
         username: str = "guest",
@@ -123,7 +124,7 @@ class MqttCaptureFixture:
         subscribe_all: bool = True,
     ) -> None:
         """Creates a new funcarg."""
-        self._buffer: t.List[MqttMessage] = []
+        self._buffer: list[MqttMessage] = []
         self._decode_utf8: bool = decode_utf8 or False
 
         self.mqtt_client = MqttClientAdapter(
@@ -157,17 +158,17 @@ class MqttCaptureFixture:
         self._buffer = []
 
     @property
-    def messages(self) -> t.List[MqttMessage]:
+    def messages(self) -> list[MqttMessage]:
         return self._buffer
 
     @property
-    def records(self) -> t.List[t.Tuple[str, t.Union[str, bytes], t.Union[t.Dict, None]]]:
+    def records(self) -> list[tuple[str, str | bytes, dict | None]]:
         return [(item.topic, item.payload, item.userdata) for item in self._buffer]
 
     def publish(
         self,
         topic: str,
-        payload: t.Union[str, bytes, bytearray, int, float, None],
+        payload: str | bytes | bytearray | float | None,
         **kwargs,
     ) -> mqtt.MQTTMessageInfo:
         message_info = self.mqtt_client.publish(topic=topic, payload=payload, **kwargs)

--- a/pytest_mqtt/model.py
+++ b/pytest_mqtt/model.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import dataclasses
-import typing as t
 
 
 @dataclasses.dataclass
@@ -9,8 +10,8 @@ class MqttMessage:
     """
 
     topic: str
-    payload: t.Union[str, bytes]
-    userdata: t.Optional[t.Union[t.Dict, None]]
+    payload: str | bytes
+    userdata: None | dict
 
 
 @dataclasses.dataclass

--- a/pytest_mqtt/mosquitto.py
+++ b/pytest_mqtt/mosquitto.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright (c) 2020-2022 Andreas Motl <andreas.motl@panodata.org>
 # Copyright (c) 2020-2022 Richard Pobering <richard.pobering@panodata.org>
 #
@@ -64,14 +62,16 @@ class Mosquitto(BaseImage):
         try:
             docker_client = docker.from_env(version=self.docker_version)
             docker_url = docker_client.api.base_url
-        except Exception:
-            raise ConnectionError("Cannot connect to the Docker daemon. Is the docker daemon running?")
+        except Exception as e:
+            raise ConnectionError("Cannot connect to the Docker daemon. Is the docker daemon running?") from e
         try:
             docker_client.ping()
-        except Exception:
-            raise ConnectionError(f"Cannot connect to the Docker daemon at {docker_url}. Is the docker daemon running?")
+        except Exception as e:
+            raise ConnectionError(
+                f"Cannot connect to the Docker daemon at {docker_url}. Is the docker daemon running?"
+            ) from e
         self.pull_image()
-        return super(Mosquitto, self).run()
+        return super().run()
 
 
 mosquitto_image = Mosquitto()

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # This is a shim to hopefully allow GitHub to detect the package.
 # The build is done with Poetry.
 


### PR DESCRIPTION
Upgrade ruff to 0.16, a lot of opt-in checks are now activated by default
running ruff with options `--fix` fixed automatically most of them.

Some non-trivial fixes:

- `# -*- coding: utf-8 -*-` is not required since python 3 as utf-8 is default
- `#!/usr/bin/env python` in the setup is deprecated since `setup.py build` is very deprecated https://packaging.python.org/en/latest/discussions/setup-py-deprecated/
- `Optional[type]` can be rewritten as `type | None` with `from __future__ import annotations` (because `|` syntax is >=3.10)
- same for `Union[type1, type2]` can be `type1 | type2`
- `except Exception:` is not recommended https://docs.astral.sh/ruff/rules/blind-except/ unless `raise ... from` of `logging.exception`